### PR TITLE
fix: Gatekeeper open spec generation: title, remove unneeded packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ open-api-spec:
 	@GOBIN=$(GOBIN_PATH) go install github.com/go-swagger/go-swagger/cmd/swagger@$(SWAGGER_VERSION)
 	@echo "Generating Open API spec"
 	@mkdir $(SWAGGER_DIR)
-	@$(GOBIN_PATH)/swagger generate spec -w ./cmd/gatekeeper -x github.com/trustbloc/orb -x github.com/trustbloc/ace/pkg/client/comparator -x github.com/trustbloc/ace/pkg/client/csh -o $(SWAGGER_OUTPUT)
+	@$(GOBIN_PATH)/swagger generate spec -w ./cmd/gatekeeper -x github.com/trustbloc/orb -x github.com/trustbloc/vct \
+		-x github.com/trustbloc/ace/pkg/restapi/vault -x github.com/trustbloc/ace/pkg/client -o $(SWAGGER_OUTPUT)
 	@echo "Validating generated spec"
 	@$(GOBIN_PATH)/swagger validate $(SWAGGER_OUTPUT)
 

--- a/cmd/gatekeeper/main.go
+++ b/cmd/gatekeeper/main.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package Gatekeeper REST API.
+// Package Gatekeeper Gatekeeper REST API.
 //
 //     Schemes: http, https
 //     Version: 0.1.0


### PR DESCRIPTION
[Issue #65](https://github.com/trustbloc/ace/issues/65)

The updated Gatekeeper spec:

<img width="612" alt="Screen Shot 2022-08-25 at 11 06 03 AM" src="https://user-images.githubusercontent.com/7861652/186612073-d234bd56-0188-4e3c-86d5-47d76aad356a.png">


Signed-off-by: Yevgen Pukhta <eugene.pukhta@gmail.com>