### PR TITLE
fix: Gatekeeper openapi spec generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ open-api-spec:
 	@GOBIN=$(GOBIN_PATH) go install github.com/go-swagger/go-swagger/cmd/swagger@$(SWAGGER_VERSION)
 	@echo "Generating Open API spec"
 	@mkdir $(SWAGGER_DIR)
-	@$(GOBIN_PATH)/swagger generate spec -w ./cmd/gatekeeper -x github.com/trustbloc/orb -x github.com/trustbloc/ace/pkg/client/comparator -x github.com/trustbloc/ace/pkg/client/csh -o $(SWAGGER_OUTPUT)
+	@$(GOBIN_PATH)/swagger generate spec -w ./cmd/gatekeeper -x github.com/trustbloc/orb -x github.com/trustbloc/vct \
+		-x github.com/trustbloc/ace/pkg/restapi/vault -x github.com/trustbloc/ace/pkg/client -o $(SWAGGER_OUTPUT)
 	@echo "Validating generated spec"
 	@$(GOBIN_PATH)/swagger validate $(SWAGGER_OUTPUT)
 

--- a/cmd/gatekeeper/main.go
+++ b/cmd/gatekeeper/main.go
@@ -4,7 +4,10 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package Gatekeeper REST API.
+// Package main Gatekeeper REST API.
+//
+// Gatekeeper helps to ensure that there are multiple authorizations for accessing protected data under
+// the given policy.
 //
 //     Schemes: http, https
 //     Version: 0.1.0


### PR DESCRIPTION
Fix issue [#65](https://github.com/trustbloc/ace/issues/65)

Changes:
- title contains a component name
- added a description field
- removed unneeded packages

The updated Gatekeeper spec screenshot:
<img width="695" alt="Screen Shot 2022-08-25 at 12 07 36 PM" src="https://user-images.githubusercontent.com/7861652/186624134-6f0631ca-0977-49e6-9ff8-33d1df8757c2.png">


Signed-off-by: Yevgen Pukhta <eugene.pukhta@gmail.com>